### PR TITLE
Add PIPELINE_BROWSERIFY_VARS setting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,10 @@ To add source maps during development (or any other browserify args)::
     if DEBUG:
         PIPELINE_BROWSERIFY_ARGUMENTS = '-d'
 
+To add variable assignments before the browserify command::
+
+    PIPELINE_BROWSERIFY_VARS = 'NODE_ENV=production'
+
 **Important:** give your entry-point file a `.browserify.js` extension::
 
     PIPELINE_JS = {

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -11,7 +11,8 @@ class BrowserifyCompiler(SubProcessCompiler):
         return path.endswith('.browserify.js')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        command = "%s %s %s > %s" % (
+        command = "%s %s %s %s > %s" % (
+            getattr(settings, 'PIPELINE_BROWSERIFY_VARS', ''),
             getattr(settings, 'PIPELINE_BROWSERIFY_BINARY', '/usr/bin/env browserify'),
             getattr(settings, 'PIPELINE_BROWSERIFY_ARGUMENTS', ''),
             infile,


### PR DESCRIPTION
This adds a `PIPELINE_BROWSERIFY_VARS` setting to optionally specify environment variables before the `browserify` command is executed. For example, I'd like to specify `NODE_ENV=production`, which (in my use-case) will allow me to strip out dev-only code during the compression phase.
