### PR TITLE
fixed the recompile all the time issue

### DIFF
--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -13,6 +13,10 @@ class BrowserifyCompiler(SubProcessCompiler):
         return path.endswith('.browserify.js')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not force and not outdated:
+            # File doesn't need to be recompiled
+            return
+
         command = "%s %s %s %s > %s" % (
             getattr(settings, 'PIPELINE_BROWSERIFY_VARS', ''),
             getattr(settings, 'PIPELINE_BROWSERIFY_BINARY', '/usr/bin/env browserify'),


### PR DESCRIPTION
I was using this library and noticed that it was reconstructing the bundle on every page load while in `DEBUG` mode. I added this change (inspired by the code in the django-pipeline repo: https://github.com/cyberdelia/django-pipeline/blob/master/pipeline/compilers/es6.py#L14) and it fixes the issue.

When the files are edited, the next page load will cause the bundle to be reconstructed correctly.

Cheers,
David
