### PR TITLE
Processing entry-point dependencies.

### DIFF
--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -2,7 +2,10 @@ from __future__ import print_function
 
 from pipeline.compilers import SubProcessCompiler
 from os.path import dirname
+import json
 from django.conf import settings
+from django.contrib.staticfiles.finders import find as static_find
+from django.core.exceptions import SuspiciousFileOperation
 
 
 class BrowserifyCompiler(SubProcessCompiler):
@@ -27,3 +30,45 @@ class BrowserifyCompiler(SubProcessCompiler):
         print('\ncommand:', command)
         return self.execute_command(command, cwd=dirname(infile))
 
+    def is_outdated(self, infile, outfile):
+
+        # Check for missing file or modified entry-point file.
+        if super(BrowserifyCompiler, self).is_outdated(infile, outfile):
+            return True
+
+        # Check if we've already calculated dependencies.
+        deps = getattr(self, '_deps', None)
+        if not deps:
+
+            # Collect dependency information.
+            command = "%s %s %s --deps %s" % (
+                getattr(settings, 'PIPELINE_BROWSERIFY_VARS', ''),
+                getattr(settings, 'PIPELINE_BROWSERIFY_BINARY', '/usr/bin/env browserify'),
+                getattr(settings, 'PIPELINE_BROWSERIFY_ARGUMENTS', ''),
+                self.storage.path(infile),
+            )
+            dep_json = self.execute_command(command) #, cwd=dirname(infile))
+
+            # Process the output data. It's JSON, and the file's path is coded
+            # in the "file" field. We also want to save the content of each file
+            # so we can check if they're outdated, which is coded under "source".
+            deps = []
+            for dep in json.loads(dep_json.decode()):
+
+                # Is this file managed by the storage?
+                try:
+                    exists = self.storage.exists(dep['file'])
+                except SuspiciousFileOperation:
+                    exists = None
+                if exists == True or exists == False:
+                    deps.append(dep['file'])
+
+            # Cache the dependencies for the next possible run.
+            self._deps = deps
+
+        # Test the dependencies to see if they're out of date.
+        for dep in deps:
+            if super(BrowserifyCompiler, self).is_outdated(dep, outfile):
+                return True
+
+        return False

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -4,7 +4,6 @@ from pipeline.compilers import SubProcessCompiler
 from os.path import dirname
 import json
 from django.conf import settings
-from django.contrib.staticfiles.finders import find as static_find
 from django.core.exceptions import SuspiciousFileOperation
 
 

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -30,6 +30,21 @@ class BrowserifyCompiler(SubProcessCompiler):
         return self.execute_command(command, cwd=dirname(infile))
 
     def is_outdated(self, infile, outfile):
+        """Check if the input file is outdated.
+
+        The difficulty with the default implementation is that any file that is
+        `require`d from the entry-point file will not trigger a recompile if it
+        is modified. This overloaded version of the method corrects this by generating
+        a list of all required files that are also a part of the storage manifest
+        and checking if they've been modified since the last compile.
+
+        The command used to generate the list of dependencies is the same as the compile
+        command but includes the `--deps` option.
+
+        WARNING: It seems to me that just generating the dependencies may take just
+        as long as actually compiling, which would mean we would be better off just
+        forcing a compile every time.
+        """
 
         # Check for missing file or modified entry-point file.
         if super(BrowserifyCompiler, self).is_outdated(infile, outfile):

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -11,7 +11,7 @@ class BrowserifyCompiler(SubProcessCompiler):
     output_extension = 'browserified.js'
 
     def match_file(self, path):
-        print('\nmatching file:', path)
+        # print('\nmatching file:', path)
         return path.endswith('.browserify.js')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
@@ -26,7 +26,7 @@ class BrowserifyCompiler(SubProcessCompiler):
             infile,
             outfile
         )
-        print('\ncommand:', command)
+        # print('\ncommand:', command)
         return self.execute_command(command, cwd=dirname(infile))
 
     def is_outdated(self, infile, outfile):


### PR DESCRIPTION
Hello! I noticed that the compiler would not run when a dependent JS file which is `require`d in the entry-point file was modified, meaning the browserified output would be incorrect until the entry-point file itself was modified.

I've just modified the `is_outdated` method to generate a list of dependencies and check if any of them are out of date as compared to the compiled browserified file.

One thing to note is that it may very well be the case that the command to generate the list of dependencies takes just as long as actually compiling, which would mean we could simply force a recompile every time and it would take the same amount of time. Given that, it may not actually be worth while merging this pull request in, I just though I'd open it and give you the opportunity to do so if you wished.

Thanks!
