### PR TITLE
Compatible with Django-Pipeline >= 1.6.x, fixed issue with Permission…

### DIFF
--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -1,30 +1,44 @@
-from pipeline.compilers import SubProcessCompiler
-from os.path import dirname
 import json
-from django.conf import settings
+import os
+
+from os.path import dirname
+from tempfile import NamedTemporaryFile
+
 from django.core.exceptions import SuspiciousFileOperation
+
+from pipeline.conf import settings as pipeline_settings
+from pipeline.compilers import SubProcessCompiler
 
 class BrowserifyCompiler(SubProcessCompiler):
     output_extension = 'browserified.js'
 
     def match_file(self, path):
-        print('\nmatching file:', path)
         return path.endswith('.browserify.js')
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
         if not force and not outdated:
-            # File doesn't need to be recompiled
-            return
-        pipeline_settings = getattr(settings, 'PIPELINE', {})
-        command = "%s %s %s %s -o %s" % (
+            return # File doesn't need to be recompiled
+        command = (
             pipeline_settings.get('BROWSERIFY_VARS', ''),
             pipeline_settings.get('BROWSERIFY_BINARY', '/usr/bin/env browserify'),
             pipeline_settings.get('BROWSERIFY_ARGUMENTS', ''),
-            infile,   
+            infile,
+            "-o",
             outfile,
         )
-        print('\ncommand:', command)
-        return self.execute_command(command.split(), cwd=dirname(infile))
+
+        '''
+        A bit of a hack, but necessary because if the first element in command is an empty str,
+        then a PermissionError will be raised by subprocess.Popen in execute_command. This is because
+        the first element in command is the program Popen tries to run
+
+        This is unneccesary after a PR in Django-Pipeline (https://github.com/jazzband/django-pipeline/pull/590)
+        is merged; until then, this can be used
+        '''
+        if command[0] == '':
+            command = command[1:]
+
+        return self.execute_command(command, cwd=dirname(infile))
 
     def is_outdated(self, infile, outfile):
         """Check if the input file is outdated.
@@ -50,29 +64,35 @@ class BrowserifyCompiler(SubProcessCompiler):
         # Check if we've already calculated dependencies.
         deps = getattr(self, '_deps', None)
         if not deps:
-
             # Collect dependency information.
-            command = "%s %s %s --deps %s" % (
-                getattr(settings, 'PIPELINE_BROWSERIFY_VARS', ''),
-                getattr(settings, 'PIPELINE_BROWSERIFY_BINARY', '/usr/bin/env browserify'),
-                getattr(settings, 'PIPELINE_BROWSERIFY_ARGUMENTS', ''),
+            command = (
+                pipeline_settings.get('BROWSERIFY_VARS', ''),
+                pipeline_settings.get('BROWSERIFY_BINARY', '/usr/bin/env browserify'),
+                pipeline_settings.get('BROWSERIFY_ARGUMENTS', ''),
+                "--deps",
                 self.storage.path(infile),
             )
-            dep_json = self.execute_command(command) #, cwd=dirname(infile))
 
-            # Process the output data. It's JSON, and the file's path is coded
-            # in the "file" field. We also want to save the content of each file
-            # so we can check if they're outdated, which is coded under "source".
-            deps = []
-            for dep in json.loads(dep_json.decode()):
+            if command[0] == '':
+                command = command[1:]
 
-                # Is this file managed by the storage?
-                try:
-                    exists = self.storage.exists(dep['file'])
-                except SuspiciousFileOperation:
-                    exists = None
-                if exists == True or exists == False:
-                    deps.append(dep['file'])
+            with NamedTemporaryFile(delete=False, dir=dirname(outfile)) as dep_json:
+                self.execute_command(command, stdout_captured=dep_json.name)
+
+                # Process the output data. It's JSON, and the file's path is coded
+                # in the "file" field. We also want to save the content of each file
+                # so we can check if they're outdated, which is coded under "source".
+                deps = []
+                with open(dep_json.name) as command_output:
+                    for dep in json.loads(command_output.read()):
+                        # Is this file managed by the storage?
+                        try:
+                            if self.storage.exists(dep['file']):
+                                deps.append(dep['file'])
+                        except SuspiciousFileOperation:
+                            pass
+                # dep_json must be removed afterwards
+                os.remove(dep_json.name)
 
             # Cache the dependencies for the next possible run.
             self._deps = deps

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -27,17 +27,6 @@ class BrowserifyCompiler(SubProcessCompiler):
             outfile,
         )
 
-        '''
-        A bit of a hack, but necessary because if the first element in command is an empty str,
-        then a PermissionError will be raised by subprocess.Popen in execute_command. This is because
-        the first element in command is the program Popen tries to run
-
-        This is unneccesary after a PR in Django-Pipeline (https://github.com/jazzband/django-pipeline/pull/590)
-        is merged; until then, this can be used
-        '''
-        if command[0] == '':
-            command = command[1:]
-
         return self.execute_command(command, cwd=dirname(infile))
 
     def is_outdated(self, infile, outfile):
@@ -72,9 +61,6 @@ class BrowserifyCompiler(SubProcessCompiler):
                 "--deps",
                 self.storage.path(infile),
             )
-
-            if command[0] == '':
-                command = command[1:]
 
             with NamedTemporaryFile(delete=False, dir=dirname(outfile)) as dep_json:
                 self.execute_command(command, stdout_captured=dep_json.name)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=io.open('README.rst', encoding='utf-8').read(),
     author='j0hnsmith',
     url='https://github.com/j0hnsmith/django-pipeline-browserify',
-    install_requires=['django-pipeline>=1.6.0'],
+    install_requires=['django-pipeline>=1.6.9'],
     packages=find_packages(),
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
- Commands that are passed int `execute_command` are now tuples instead of strings, which is what Django-Pipeline expects.
- Fixed an issue that was causing `PermissionError`s; the first element in `command` cannot be an empty string, so it will check for that. Becomes unnecessary after [this PR](https://github.com/jazzband/django-pipeline/pull/590) is merged
- Fixed the `is_outdated` method, as output isn't returned from `execute_command` so it's captured as `stdout_captured`
- Simplified some of the logic
