### PR TITLE
Fixup BROWSERIFY_BINARY default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,13 @@ To set environment varaibles specific to the browserify command::
 
 (Note that for an actual production build, this example is not sufficient. You'll probably want to use a transform like loose-envify so the minifier can optimize out debug statements. Browserify doesn't usually pass environment variables like that shown above into the compiled code; but it may effect the runtime behavior of browserify itself.)
 
+To use a local install of the browserify command line utility (or if it is not in your PATH for some other reason), you can override the command used::
+
+    PIPELINE['BROWSERIFY_BINARY'] = "/custom/path/to/browserify"
+    
+    # ...or perhaps something like this:
+    PIPELINE['BROWSERIFY_BINARY'] = os.path.join(REPO_ROOT, "node_modules/.bin", "browserify"),
+
 
 **Important:** give your entry-point file a `.browserify.js` extension::
 

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -26,7 +26,7 @@ class BrowserifyCompiler(SubProcessCompiler):
     
     def _get_cmd_parts(self):
         pipeline_settings = getattr(settings, 'PIPELINE', {})
-        tool = pipeline_settings.get('BROWSERIFY_BINARY', "/usr/bin/env browserify")
+        tool = pipeline_settings.get('BROWSERIFY_BINARY', "browserify")
         
         old_args = pipeline_settings.get('BROWSERIFY_ARGUMENTS', '')
         if old_args:

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -15,7 +15,10 @@ class BrowserifyCompiler(SubProcessCompiler):
     # similar to old removed in https://github.com/jazzband/django-pipeline/commit/1f6b48ae74026a12f955f2f15f9f08823d744515
     def simple_execute_command(self, cmd, **kwargs):
         import subprocess
-        pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+        try:
+            pipe = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+        except OSError as e:
+            raise CompilerError("Compiler failed to execute. (%s)" % e, command=cmd, error_output="Executing the compiler resulted in an %s from the system.\n\nThis is most likely due to the `browserify` executable not being found in your PATH (if it is installed globally), or a misconfigured BROWSERIFY_BINARY setting (if you are using a non-global install)." % repr(e))
         stdout, stderr = pipe.communicate()
         if self.verbose:
             print stdout


### PR DESCRIPTION
My last pull request introduced a bug with the default BROWSERIFY_BINARY, since with the new `simple_execute_command` it doesn't work to pass the "env browsersify" as the first command argument — technically "env" would need to be the command and "browserify" would need to be the first argument.

Rather than trying to handle that situation with "/usr/bin/env browserify", I've simply made the default be "browserify" instead and the same behavior should result. I'm hopeful this will also fix #17 for Windows users who have browserify in their path.

(This also adds documentation for `BROWSERIFY_BINARY` too.)