### PR TITLE
Fix up bad calls to browserify CLI after first compile

### DIFF
--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -59,8 +59,7 @@ class BrowserifyCompiler(SubProcessCompiler):
             return
         
         tool, args, env = self._get_cmd_parts()
-        args.extend([infile, '--outfile', outfile])
-        cmd = [tool] + args
+        cmd = [tool] + args + [infile, '--outfile', outfile]
         
         if self.verbose:
             print "compile_file command:", cmd, env
@@ -89,8 +88,7 @@ class BrowserifyCompiler(SubProcessCompiler):
         
         # Otherwise we need to see what dependencies there are now, and if they're modified.
         tool, args, env = self._get_cmd_parts()
-        args.extend(['--list', infile])
-        cmd = [tool] + args
+        cmd = [tool] + args + ['--list', infile]
         if self.verbose:
             print "is_outdated command:", cmd, env
         dep_list = self.simple_execute_command(cmd, env=env)


### PR DESCRIPTION
If a user migrated to my new `BROWSERIFY_ARGS` setting, the arguments array ended up getting extended *each time* this plugin got called, breaking things pretty badly 🤕

This could yield errors like this when running collectstatic:

```
pipeline.exceptions.CompilerError: Compiler returned non-zero exit status 1
```

Or inline output from browsersify during development:

```
Error compiling JavaScript package "my_file"
Command:

browserify --transform [ babelify --presets [ es2015 react ] --plugins [ transform-object-rest-spread transform-class-properties ] ] my_proj/collected_static_files/jsx/my_file.browserify.js --outfile my_proj/collected_static_files/jsx/my_file.browserify.browserified.js
Errors:

events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open 'my_proj/collected_static_files/jsx/my_file.browserify.browserified.js,my_proj/collected_static_files/jsx/my_file.browserify.browserified.js.tmp-browserify-62282847839241406440'
    at Error (native)
```

Basically, this library would end up passing multiple `--outfile` arguments to browserify which it doesn't allow. This fixes so that a new list is created rather than modifying the settings one in place.

(Might be worth considering to always return a copy from `_get_cmd_parts` so that issues like this can't get re-introduced, but this is sufficient in the current codebase.)

---

Workaround without this fix is to go back to using the older `BROWSERIFY_ARGUMENTS` string setting.