### PR TITLE
Fix crash caused by mixup of bytes and str

### DIFF
--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -25,7 +25,7 @@ class BrowserifyCompiler(SubProcessCompiler):
             print(stderr)
         if pipe.returncode != 0:
             raise CompilerError("Compiler returned non-zero exit status %i" % pipe.returncode, command=cmd, error_output=stderr)
-        return stdout
+        return stdout.decode()
     
     def _get_cmd_parts(self):
         pipeline_settings = getattr(settings, 'PIPELINE', {})

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from pipeline.compilers import SubProcessCompiler
 from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation


### PR DESCRIPTION
This fixes dependency-based checking for "outdatedness".

Popen.communicate() return a tuple of bytes, but the rest of the code
expects str. Decoding the bytes object fixes this. Some (very weird)
outputs may now fail with UnicodeDecodeError, but that'd probably be
indicative of a bug elsewhere.