### PR TITLE
Add and document "shallow recompiles" option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,20 @@ And add it as a compiler to pipeline in your django `settings.py`::
         # ...
     )
 
+**Important:** give your entry-point file a `.browserify.js` extension::
+
+    PIPELINE = {
+        # ...
+        'javascript':{
+            'browserify': {
+                'source_filenames' : (
+                    'js/entry-point.browserify.js',
+                ),
+                'output_filename': 'js/entry-point.js',
+            },
+        }
+    }
+
 To add source maps during development (or any other browserify args)::
 
     if DEBUG:
@@ -46,19 +60,6 @@ To use a local install of the browserify command line utility (or if it is not i
     PIPELINE['BROWSERIFY_BINARY'] = os.path.join(REPO_ROOT, "node_modules/.bin", "browserify"),
 
 
-**Important:** give your entry-point file a `.browserify.js` extension::
-
-    PIPELINE = {
-        # ...
-        'javascript':{
-            'browserify': {
-                'source_filenames' : (
-                    'js/entry-point.browserify.js',
-                ),
-                'output_filename': 'js/entry-point.js',
-            },
-        }
-    }
 
 To suggest a feature or report a bug:
 https://github.com/j0hnsmith/django-pipeline-browserify/issues

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,9 @@ To use a local install of the browserify command line utility (or if it is not i
     # ...or perhaps something like this:
     PIPELINE['BROWSERIFY_BINARY'] = os.path.join(REPO_ROOT, "node_modules/.bin", "browserify"),
 
+By default a full check of your entry point **and its dependencies** is performed to see if the output is stale. This produces the most correct behavior, but with a large JavaScript codebase can cause very slow page refreshes — even when nothing has changed! To use only the main entry point's modification time when determining if recompilation is needed, set:
+
+    PIPELINE['BROWSERIFY_SHALLOW_RECOMPILES'] = True
 
 
 To suggest a feature or report a bug:

--- a/pipeline_browserify/compiler.py
+++ b/pipeline_browserify/compiler.py
@@ -86,6 +86,10 @@ class BrowserifyCompiler(SubProcessCompiler):
         if super(BrowserifyCompiler, self).is_outdated(infile, outfile):
             return True
         
+        pipeline_settings = getattr(settings, 'PIPELINE', {})
+        if pipeline_settings.get('BROWSERIFY_SHALLOW_RECOMPILES', False):
+            return False
+        
         # Otherwise we need to see what dependencies there are now, and if they're modified.
         tool, args, env = self._get_cmd_parts()
         cmd = [tool] + args + ['--list', infile]


### PR DESCRIPTION
Recursively checking dependencies is the most correct, but it can also be very slow. This patch makes the choice configurable. By setting `BROWSERIFY_SHALLOW_RECOMPILES` true, only the entry point will be checked rather than all its dependencies.